### PR TITLE
Update installation procedure for pip packages

### DIFF
--- a/README.rtf
+++ b/README.rtf
@@ -3,22 +3,15 @@ Hello! Thank you for your interest in DialectDecoder. Here is an overview of how
 What you need: A selection of songs that you want to analyze. See the DialectDecoder/data/cut_songs folder for an example of how the songs are organized and sorted.
 
 Packages needed:
-	•	os
 	•	pygame
 	•	torch
 	•	tqdm
-	•	PIL
+	•	Pillow
 	•	matplotlib
 	•	pandas
-	•	shutil
-	•	datetime
-	•	csv
-	•	sklearn
-	•	math
-	•	pickle
+	•	scikit-learn
 	•	librosa
 	•	numpy
-	•	gc
 
 What each script in DialectDecoder does: 
 


### PR DESCRIPTION
Note os, pickle, datetime, math, shutil, csv and gc are all modules provided by python by default.

Module PIL is provided by pip package Pillow.

Module sklearn is provided by pip package scikit-learn (sklearn package on pip is  deprecated).